### PR TITLE
infra: Fix repository url in main package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.6.2](https://github.com/JulianKarhof/etournity/compare/v1.6.1...v1.6.2) (2023-03-21)
+## [1.6.2](https://github.com/etournity/etournity/compare/v1.6.1...v1.6.2) (2023-03-21)
 
 **Note:** Version bump only for package etournity
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "etournity",
   "private": true,
-  "repository": "https://github.com/JulianKarhof/etournity.git",
+  "repository": "https://github.com/etournity/etournity.git",
   "author": "Julian Karhof <julian@karhof.net>",
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
The repository url in the package.json threw off lerna into thinking we're still using the original repository.