### PR TITLE
fix(Discovery): Tournaments Query fails when not logged in

### DIFF
--- a/packages/client/pages/tournaments/index.tsx
+++ b/packages/client/pages/tournaments/index.tsx
@@ -34,6 +34,7 @@ const Index: React.FC = () => {
         ParticipantRoleType.Moderator,
       ],
     },
+    skip: user === undefined,
     onError: (error) => handleError(error),
   })
   if (tournamentsLoading || participatingLoading) return <Loader />

--- a/packages/server/src/api/tournament/tournament.type.ts
+++ b/packages/server/src/api/tournament/tournament.type.ts
@@ -96,17 +96,19 @@ export const TournamentType = objectType({
       type: 'ParticipantRoleType',
 
       resolve: async (tournament, _, { user, prisma }) => {
-        const participantRoles = (
-          await prisma.participant.findFirst({
-            where: {
-              tournamentId: tournament.id,
-              userId: user.id,
-            },
-            select: {
-              roles: { select: { type: true } },
-            },
-          })
-        )?.roles
+        const participantRoles = user
+          ? (
+              await prisma.participant.findFirst({
+                where: {
+                  tournamentId: tournament.id,
+                  userId: user.id,
+                },
+                select: {
+                  roles: { select: { type: true } },
+                },
+              })
+            )?.roles
+          : null
 
         return participantRoles?.length
           ? participantRoles.map((role) => role.type)


### PR DESCRIPTION


## Proposed changes

The calculated field `userRoles`, used to get the roles a user fulfills in a tournament, threw an error when not logged in. 
We now simply check if there is a user logged in and return `null` otherwise.

We now also check for a logged in user before running the query for user related tournaments.

closes #33 
<!-- Describe the big picture of your changes here to communicate to the maintainers why they should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/etournity/etournity/#contributing) doc

