### PR TITLE
feat(Discovery): tournament search

### DIFF
--- a/packages/client/components/tournament/hub/issueTracker/index.tsx
+++ b/packages/client/components/tournament/hub/issueTracker/index.tsx
@@ -127,7 +127,7 @@ export const IssueTracker: React.FC<IssueTrackerProps> = ({
         maxHeight="29rem"
         emptyPlaceholder={
           <div className={styles.empty}>
-            <Empty noTitle description="No tickets issued." />
+            <Empty description="No tickets issued." />
           </div>
         }
       >

--- a/packages/client/components/tournament/hub/participantManager/index.tsx
+++ b/packages/client/components/tournament/hub/participantManager/index.tsx
@@ -245,7 +245,6 @@ export const ParticipantManager: React.FC<ParticipantManagerProps> = ({
           emptyPlaceholder={
             <div className={styles.empty}>
               <Empty
-                noTitle
                 description={
                   playerCount === 0 ? 'No Players Yet' : 'No Results'
                 }

--- a/packages/client/components/tournament/tournamentCard/index.tsx
+++ b/packages/client/components/tournament/tournamentCard/index.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import styles from './tournamentCard.module.scss'
 import Link from 'next/link'
 import { Except } from 'type-fest'
-import { Avatar, Box, Chip, Paper, Typography } from '@mui/material'
+import { Avatar, Box, BoxProps, Chip, Paper, Typography } from '@mui/material'
 import { Icon } from '@components/ui/icon'
 
 import DnsOutlined from '@mui/icons-material/DnsOutlined'
@@ -21,7 +21,8 @@ import { TournamentStatusChip } from '../tournamentHeader/tournamentStatusChip'
 import { InfoTag } from './infoTag'
 import { RoleInfo } from './roleInfo'
 import dayjs from 'dayjs'
-export interface TournamentCardProps {
+import classNames from 'classnames'
+export interface TournamentCardProps extends BoxProps {
   tournament: TournamentCardInput
   toHub?: boolean
   backgroundSrc?: string
@@ -83,10 +84,11 @@ export const TournamentCard: React.FC<TournamentCardProps> = ({
   tournament,
   toHub,
   backgroundSrc,
+  className,
   ...rest
 }) => (
   <Link passHref href={`/tournament/${tournament.id}${toHub ? '/hub' : ''}`}>
-    <Box className={styles.card} {...rest}>
+    <Box className={classNames(styles.card, className)} {...rest}>
       <Paper className={styles.cardContent}>
         <Box className={styles.picture}>
           <TournamentStatusChip

--- a/packages/client/components/ui/empty/empty.module.scss
+++ b/packages/client/components/ui/empty/empty.module.scss
@@ -6,25 +6,21 @@
   align-items: center;
 
   .title {
-    font-weight: 900;
-    font-size: 1.5rem;
-    line-height: 1.8125rem;
-    letter-spacing: 0.69rem;
-    text-indent: 0.69rem;
-    margin-top: 1.5rem;
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
     margin-bottom: 0;
   }
 
   .description {
     color: $middle-grey;
-    font-weight: 900;
-    font-size: 1.5rem;
-    line-height: 1.8125rem;
-    margin-top: 1rem;
+    font-weight: 700;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    margin-top: 0.5rem;
   }
 
   .actions {
-    margin-top: 1rem;
     :not(:last-child) {
       margin-right: 0.5rem;
     }

--- a/packages/client/components/ui/empty/index.tsx
+++ b/packages/client/components/ui/empty/index.tsx
@@ -1,12 +1,11 @@
 import React, { ReactNode } from 'react'
 import styles from './empty.module.scss'
-import { Icon } from '../icon/'
+import { Box, Typography } from '@mui/material'
 
 export interface EmptyProps {
   children?: ReactNode
   description?: string
   title?: string
-  noTitle?: boolean
   icon?: ReactNode
   actions?: ReactNode | ReactNode[]
 }
@@ -15,23 +14,15 @@ export const Empty: React.FC<EmptyProps> = ({
   children,
   description,
   title,
-  noTitle,
   icon,
   actions,
 }) => (
-  <div className={styles.wrapper}>
-    {icon ?? (
-      <Icon
-        variant="windCircle"
-        rotate="right"
-        size={5}
-        color={styles.middleGrey}
-      />
-    )}
-    {!noTitle && <p className={styles.title}>{title ?? 'NOTHING IN HERE'}</p>}
-    <div className={styles.description}>
-      {children ?? description ?? 'NOTHING IN HERE'}
-    </div>
-    {actions && <div className={styles.actions}>{actions}</div>}
-  </div>
+  <Box className={styles.wrapper}>
+    {icon}
+    <Typography className={styles.title}>{title} </Typography>
+    <Box className={styles.description}>
+      {children ?? <Typography>{description}</Typography>}
+    </Box>
+    {actions && <Box className={styles.actions}>{actions}</Box>}
+  </Box>
 )

--- a/packages/client/pages/tournaments/index.module.scss
+++ b/packages/client/pages/tournaments/index.module.scss
@@ -22,7 +22,11 @@
       height: 15rem;
     }
   }
-
+  .empty {
+    flex: 1;
+    padding: 3rem;
+    border-radius: 0.5rem;
+  }
   .tournamentLists {
     flex: 3;
     display: flex;
@@ -48,18 +52,18 @@
       row-gap: 0.75rem;
       column-gap: 1rem;
       flex-wrap: wrap;
-      > * {
+      > .tournamentCard {
         flex: 1 0 100%;
       }
       @include breakpoint(md) {
         row-gap: 1rem;
-        > * {
+        > .tournamentCard {
           flex: 0 0 calc(50% - 0.5rem);
         }
       }
       @include breakpoint(lg) {
         row-gap: 0.625rem;
-        > * {
+        > .tournamentCard {
           flex: 1 0 100%;
         }
       }

--- a/packages/client/pages/tournaments/index.tsx
+++ b/packages/client/pages/tournaments/index.tsx
@@ -69,7 +69,7 @@ const Index: React.FC = () => {
       const fuse = new Fuse(tournaments, {
         includeScore: true,
         threshold: 0.6,
-        keys: ['title', 'hostUser.displayName'],
+        keys: ['title', 'hostUser.displayName', 'game.title'],
       })
 
       const searchedTournaments =

--- a/packages/client/pages/tournaments/index.tsx
+++ b/packages/client/pages/tournaments/index.tsx
@@ -116,24 +116,22 @@ const Index: React.FC = () => {
 
   return (
     <Box className={styles.discovery}>
-      {!isMobile &&
-        breakpoint !== 'lg' &&
-        process.env.ETY_ENV !== 'production' && (
-          <Box className={styles.searchAndFilter}>
-            <Paper className={styles.search}>
-              <TournamentSearch
-                value={tournamentSearch}
-                onChange={(e) => setTournamentSearch(e.target.value)}
-              />
-            </Paper>
+      {!isMobile && breakpoint !== 'lg' && (
+        <Box className={styles.searchAndFilter}>
+          <Paper className={styles.search}>
+            <TournamentSearch
+              value={tournamentSearch}
+              onChange={(e) => setTournamentSearch(e.target.value)}
+            />
+          </Paper>
 
-            <Paper className={styles.filter}>
-              {'Filters (Coming Soon) \u2122'}
-            </Paper>
-          </Box>
-        )}
+          <Paper className={styles.filter}>
+            {'Filters (Coming Soon) \u2122'}
+          </Paper>
+        </Box>
+      )}
       <Box className={styles.tournamentLists}>
-        {breakpoint === 'lg' && process.env.ETY_ENV !== 'production' && (
+        {breakpoint === 'lg' && (
           <Paper className={styles.search}>
             <TournamentSearch
               value={tournamentSearch}

--- a/packages/client/pages/tournaments/index.tsx
+++ b/packages/client/pages/tournaments/index.tsx
@@ -53,14 +53,14 @@ const Index: React.FC = () => {
       if (!tournaments?.length) {
         if (participating) {
           return [
-            <Paper key="not_participating">
+            <Paper key="not_participating" className={styles.empty}>
               <Empty title="You are not participating in any tournaments..." />
             </Paper>,
           ]
         }
 
         return [
-          <Paper key="no_tournaments">
+          <Paper key="no_tournaments" className={styles.empty}>
             <Empty title="Unable to find tournaments..." />
           </Paper>,
         ]
@@ -81,8 +81,11 @@ const Index: React.FC = () => {
 
       if (!searchedTournaments?.length) {
         return [
-          <Paper key="not_search_match">
-            <Empty title="No tournaments match you current search..." />
+          <Paper key="not_search_match" className={styles.empty}>
+            <Empty
+              title="No tournaments match you current search..."
+              description="Create a tournament to liven up the place!"
+            />
           </Paper>,
         ]
       }
@@ -93,6 +96,7 @@ const Index: React.FC = () => {
           <TournamentCard
             key={element.id}
             tournament={element}
+            className={styles.tournamentCard}
             backgroundSrc="/assets/images/thisIsABanner.png"
             toHub={element.hostUser.id === user?.id}
             data-cy="tournamentCard"


### PR DESCRIPTION
## Proposed changes

Add a search field for tournaments using fuzzy search (keys = tournament title, organizer name).

Also updates Empty component to use MUI components and improve styling to closer represent current design language.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/etournity/etournity/#contributing) doc
- [x] Lint and unit tests pass locally with my changes


