### PR TITLE
feat: add check for stale tournaments

### DIFF
--- a/packages/server/src/queues/noShow.queue.ts
+++ b/packages/server/src/queues/noShow.queue.ts
@@ -4,5 +4,7 @@ import { REDIS_URL } from '../globals'
 export const noShowQueue = new Queue('noShow', REDIS_URL, {
   defaultJobOptions: {
     attempts: 3,
+    removeOnComplete: { age: 86400 }, // Jobs will be kept for 1 day
+    removeOnFail: { age: 86400 }, // Jobs will be kept for 1 day
   },
 })

--- a/packages/server/src/queues/staleTournaments.queue.ts
+++ b/packages/server/src/queues/staleTournaments.queue.ts
@@ -1,0 +1,35 @@
+import { TournamentStatus } from '@prisma/client'
+import Queue, { ProcessCallbackFunction } from 'bull'
+import { prisma, REDIS_URL } from '../globals'
+import dayjs from 'dayjs'
+export const closeStaleQueue = new Queue('staleTournaments', REDIS_URL, {
+  defaultJobOptions: {
+    attempts: 3,
+    removeOnComplete: { age: 86400 }, // Jobs will be kept for 1 day
+    removeOnFail: { age: 86400 }, // Jobs will be kept for 1 day
+  },
+})
+export const closeStaleProcessor: ProcessCallbackFunction<null> = async (
+  _,
+  done
+) => {
+  const tournamentsToClose = await prisma.tournament.findMany({
+    where: {
+      AND: {
+        status: {
+          notIn: [TournamentStatus.CANCELLED, TournamentStatus.FINISHED],
+        },
+        updatedAt: { lte: dayjs().subtract(3, 'days').toDate() },
+      },
+    },
+    select: {
+      id: true,
+    },
+  })
+  await prisma.tournament.updateMany({
+    where: { id: { in: tournamentsToClose.map(({ id }) => id) } },
+    data: { status: TournamentStatus.FINISHED },
+  })
+
+  done()
+}

--- a/packages/server/src/queues/staleTournaments.queue.ts
+++ b/packages/server/src/queues/staleTournaments.queue.ts
@@ -29,7 +29,7 @@ export const closeStaleProcessor: ProcessCallbackFunction<null> = async (
           notIn: [TournamentStatus.CANCELLED, TournamentStatus.FINISHED],
         },
         updatedAt: { lt: dayjs().subtract(7, 'days').toDate() },
-        date: { lt: dayjs().toDate() },
+        date: { lt: dayjs().subtract(1, 'day').toDate() },
       },
     },
     select: {


### PR DESCRIPTION
<!--
Pull request title should be based on conventional commits (https://www.conventionalcommits.org/en/v1.0.0/):

<type>(<optional scope>): <description>

types: feat, fix, docs, infra, chore, style, refactor, test,

Example: chore(docs): update pull_request_template
-->

## Proposed changes
Adds a cronjob running every Monday at 4:00am, which checks for stale tournaments (not updated in >3 days) and closes them (status -> Finished)
Reference: #45 
closes #46 

I have also added a setting for the bull queues, which now deletes failed/completed jobs older than 1 day. This prevents redis storage from filling up since the default is to keep all completed and failed jobs.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/etournity/etournity/#contributing) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

